### PR TITLE
Log warning when unknown email template is requested

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -37,7 +37,9 @@ pub fn get(template_id: &str) -> Option<Template> {
         "editor-report" => Some(editor_report::editor_report),
         "personal-recommendation" => Some(personal_recommendation::personal_recommendation),
         "playlist-notification" => Some(playlist_notification::playlist_notification),
-        _ =>  {
-    tracing::warn!("Unknown email template requested: {}", template_id);
-    None
+                _ => {
+            tracing::warn!("Unknown email template requested: {}", template_id);
+            None
+        },
+    }
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -37,6 +37,7 @@ pub fn get(template_id: &str) -> Option<Template> {
         "editor-report" => Some(editor_report::editor_report),
         "personal-recommendation" => Some(personal_recommendation::personal_recommendation),
         "playlist-notification" => Some(playlist_notification::playlist_notification),
-        _ => None,
-    }
+        _ =>  {
+    tracing::warn!("Unknown email template requested: {}", template_id);
+    None
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -21,6 +21,7 @@ pub(crate) enum TemplateError {
     #[error("Failed to parse parameters: {0}")]
     SerdeJson(#[from] serde_json::Error),
 }
+
 type Template = fn(Value, Locale) -> Result<Mjml, TemplateError>;
 
 pub fn get(template_id: &str) -> Option<Template> {
@@ -37,7 +38,7 @@ pub fn get(template_id: &str) -> Option<Template> {
         "editor-report" => Some(editor_report::editor_report),
         "personal-recommendation" => Some(personal_recommendation::personal_recommendation),
         "playlist-notification" => Some(playlist_notification::playlist_notification),
-                _ => {
+        _ => {
             tracing::warn!("Unknown email template requested: {}", template_id);
             None
         },


### PR DESCRIPTION
Currently, `templates::get` silently returns `none` when an unknown template ID is requested.

This change adds a warning log using `tracing::warn!` so that unexpected template IDs can be identified more easily in logs.