### PR TITLE
chore: Release mb-mail-service version 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -730,9 +730,9 @@ checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "email-encoding"
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "impl-more"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fe6e7b5d5fa3d2327856122655a0f8fbde0e081e877835bf43bad1ca2780bc"
+checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
 
 [[package]]
 name = "indexmap"
@@ -1709,7 +1709,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mb-mail-service"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "axum-prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "mb-mail-service"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 publish = false
 license = "GPL-2.0-or-later"

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is a build-time crate, is widely used and is a transitive dependency of multiple crates." },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is a build-time transitive dependency via mrmx-macros; no safe upgrade available." },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/deny.toml
+++ b/deny.toml
@@ -240,7 +240,7 @@ allow-git = []
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = []
+github = ["JadedBlueEyes"]
 # 1 or more gitlab.com organizations to allow git sources for
 gitlab = []
 # 1 or more bitbucket.org organizations to allow git sources for

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -24,6 +24,7 @@ use crate::{
     send::{send_mail_bulk_route, send_mail_mjml_route, send_mail_route, MailTransport},
 };
 use axum::{
+    http::StatusCode,
     response::Redirect,
     routing::{get, post},
     Json,
@@ -153,7 +154,7 @@ async fn service(mailer: MailTransport) -> axum::Router {
             TraceLayer::new_for_http(),
             // Give a universal timeout to prevent
             // DOS and for graceful shutdown
-            TimeoutLayer::new(Duration::from_secs(60)),
+            TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, Duration::from_secs(60)),
         ))
         // Place the healthcheck last to bypass previously set layers
         .route("/healthcheck", get(healthcheck));


### PR DESCRIPTION
## Summary
- Bump version to 0.5.1 in Cargo.toml and Cargo.lock